### PR TITLE
Export TransitionStackNavigationOptions from index.ts

### DIFF
--- a/packages/react-native-screen-transitions/src/index.ts
+++ b/packages/react-native-screen-transitions/src/index.ts
@@ -49,4 +49,4 @@ export type { TransitionStackNavigatorTypeBag, TransitionStackNavigationOptions 
 /**
  * Configuration type for screen transitions. Use this to build custom presets.
  */
-export type { TransitionConfig } from "./types";
+export type { TransitionConfig, ScreenInterpolationProps } from "./types";

--- a/packages/react-native-screen-transitions/src/index.ts
+++ b/packages/react-native-screen-transitions/src/index.ts
@@ -44,7 +44,7 @@ export default {
 export { useScreenAnimation };
 
 // Navigator type
-export type { TransitionStackNavigatorTypeBag } from "./navigator/create-transitionable-stack-navigator";
+export type { TransitionStackNavigatorTypeBag, TransitionStackNavigationOptions } from "./navigator/create-transitionable-stack-navigator";
 
 /**
  * Configuration type for screen transitions. Use this to build custom presets.


### PR DESCRIPTION
Adds export of `TransitionStackNavigationOptions` from index.ts. This fixes a type issue that appears when using the library as recommended in the Expo Router instructions.