### PR TITLE
Fix typo in android script command

### DIFF
--- a/examples/expo-router-example/package.json
+++ b/examples/expo-router-example/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.3",
   "scripts": {
     "start": "expo start --dev-client",
-    "android": "expo run:andro1id",
+    "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll"


### PR DESCRIPTION
Fixes a typo in the package.json of expo-router-example