### PR TITLE
fix: Export namespace should be first transformed by @babel/plugin-transform-export-namespace-from

### DIFF
--- a/packages/react-native-screen-transitions/src/configs/index.ts
+++ b/packages/react-native-screen-transitions/src/configs/index.ts
@@ -1,2 +1,14 @@
-export * as presets from "./presets";
-export * as specs from "./specs";
+import { DraggableCard, ElasticCard, SlideFromBottom, SlideFromTop, ZoomIn } from './presets';
+import { DefaultSpec } from './specs';
+
+export const specs = {
+  DefaultSpec,
+};
+
+export const presets = {
+  SlideFromTop,
+  ZoomIn,
+  SlideFromBottom,
+  DraggableCard,
+  ElasticCard,
+};

--- a/packages/react-native-screen-transitions/src/utils/index.ts
+++ b/packages/react-native-screen-transitions/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * from "./animation/animate";


### PR DESCRIPTION
It looks like babel need an extra plugin to handle wildcard exports.

To avoid the overhead I've removed them.

this should fix:

https://github.com/eds2002/react-native-screen-transitions/issues/7