### PR TITLE
fix: move NEAR_ZERO_THRESHOLD to function body instead

### DIFF
--- a/.changeset/early-heads-call.md
+++ b/.changeset/early-heads-call.md
@@ -1,0 +1,5 @@
+---
+"react-native-screen-transitions": patch
+---
+
+Move NEAR_ZERO_THRESHOLD to the function body instead, also remove it as a prop required prop since it's not needed.

--- a/packages/react-native-screen-transitions/src/types/utils.ts
+++ b/packages/react-native-screen-transitions/src/types/utils.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/suspicious/noExplicitAny: <>
 export type Any = any;
 
 export type Complete<T> = { [K in keyof T]-?: Exclude<T[K], undefined> };

--- a/packages/react-native-screen-transitions/src/utils/bounds/_utils/styles.ts
+++ b/packages/react-native-screen-transitions/src/utils/bounds/_utils/styles.ts
@@ -1,9 +1,10 @@
 import type { ImageStyle, StyleProp, TextStyle, ViewStyle } from "react-native";
 import { isSharedValue } from "react-native-reanimated";
+import type { Any } from "../../../types/utils";
 
 type AnyStyle = ViewStyle | TextStyle | ImageStyle;
 type StyleValue = StyleProp<AnyStyle>;
-type PlainStyleObject = Record<string, any>;
+type PlainStyleObject = Record<string, Any>;
 
 function mergeStyleArrays<T extends StyleValue>(style: T): T {
 	"worklet";

--- a/packages/react-native-screen-transitions/src/utils/gesture/reset-gesture-values.ts
+++ b/packages/react-native-screen-transitions/src/utils/gesture/reset-gesture-values.ts
@@ -31,6 +31,7 @@ export const resetGestureValues = ({
 	const nx =
 		gestures.normalizedX.value ||
 		event.translationX / Math.max(1, dimensions.width);
+
 	const ny =
 		gestures.normalizedY.value ||
 		event.translationY / Math.max(1, dimensions.height);

--- a/packages/react-native-screen-transitions/src/utils/gesture/velocity.ts
+++ b/packages/react-native-screen-transitions/src/utils/gesture/velocity.ts
@@ -41,11 +41,10 @@ const normalize = (velocityPixelsPerSecond: number, screenSize: number) => {
 const calculateRestoreVelocity = (
 	currentValueNormalized: number,
 	baseVelocityNormalized: number,
-	threshold: number = NEAR_ZERO_THRESHOLD,
 ) => {
 	"worklet";
 
-	if (Math.abs(currentValueNormalized) < threshold) return 0;
+	if (Math.abs(currentValueNormalized) < NEAR_ZERO_THRESHOLD) return 0;
 
 	const directionTowardZero = Math.sign(currentValueNormalized) || 1;
 	const clampedVelocity = Math.min(Math.abs(baseVelocityNormalized), 1);


### PR DESCRIPTION
### Summary 
Remove threshold property as it wasn't being used anywhere + move NEAR_ZERO_THRESHOLD to the function body. Fixes #44 