### PR TITLE
feat: added support for auto snap points

### DIFF
--- a/packages/react-native-screen-transitions/src/shared/__tests__/validate-snap-points.test.ts
+++ b/packages/react-native-screen-transitions/src/shared/__tests__/validate-snap-points.test.ts
@@ -144,4 +144,60 @@ describe("validateSnapPoints", () => {
 			expect(result.maxSnapPoint).toBe(1.5);
 		});
 	});
+
+	describe("'auto' snap point", () => {
+		it("returns hasSnapPoints true for ['auto']", () => {
+			const result = validateSnapPoints({ snapPoints: ["auto"] });
+			expect(result.hasSnapPoints).toBe(true);
+		});
+
+		it("sets hasAutoSnapPoint true when 'auto' is present", () => {
+			const result = validateSnapPoints({ snapPoints: ["auto"] });
+			expect(result.hasAutoSnapPoint).toBe(true);
+		});
+
+		it("sets hasAutoSnapPoint false when no 'auto' is present", () => {
+			const result = validateSnapPoints({ snapPoints: [0.5, 1] });
+			expect(result.hasAutoSnapPoint).toBe(false);
+		});
+
+		it("excludes 'auto' from the numeric snapPoints array", () => {
+			const result = validateSnapPoints({ snapPoints: ["auto"] });
+			expect(result.snapPoints).toEqual([]);
+		});
+
+		it("returns -1 for min and max when only 'auto' is present", () => {
+			const result = validateSnapPoints({ snapPoints: ["auto"] });
+			expect(result.minSnapPoint).toBe(-1);
+			expect(result.maxSnapPoint).toBe(-1);
+		});
+
+		it("includes numeric points alongside 'auto'", () => {
+			const result = validateSnapPoints({ snapPoints: ["auto", 1.0] });
+			expect(result.hasSnapPoints).toBe(true);
+			expect(result.hasAutoSnapPoint).toBe(true);
+			expect(result.snapPoints).toEqual([1.0]);
+			expect(result.maxSnapPoint).toBe(1.0);
+		});
+
+		it("sorts numeric points and excludes 'auto' from the array", () => {
+			const result = validateSnapPoints({ snapPoints: [1.0, "auto", 0.5] });
+			expect(result.snapPoints).toEqual([0.5, 1.0]);
+			expect(result.hasAutoSnapPoint).toBe(true);
+		});
+
+		it("sets minSnapPoint to 0 when canDismiss and 'auto' is the only point", () => {
+			const result = validateSnapPoints({
+				snapPoints: ["auto"],
+				canDismiss: true,
+			});
+			expect(result.minSnapPoint).toBe(0);
+		});
+
+		it("does not mutate original array containing 'auto'", () => {
+			const original: ("auto" | number)[] = [1, "auto", 0.5];
+			validateSnapPoints({ snapPoints: original });
+			expect(original).toEqual([1, "auto", 0.5]);
+		});
+	});
 });

--- a/packages/react-native-screen-transitions/src/shared/animation/snap-to.ts
+++ b/packages/react-native-screen-transitions/src/shared/animation/snap-to.ts
@@ -11,7 +11,18 @@ const getSortedSnapPoints = (
 ): number[] | null => {
 	const snapPoints = descriptor.options?.snapPoints;
 	if (!snapPoints || snapPoints.length === 0) return null;
-	return [...snapPoints].sort((a, b) => a - b);
+
+	// Resolve 'auto' to the measured fraction stored in AnimationStore
+	const autoVal = AnimationStore.getAnimation(
+		descriptor.route.key,
+		"autoSnapPoint",
+	).value;
+
+	const resolved = snapPoints
+		.map((p) => (p === "auto" ? autoVal : p))
+		.filter((p): p is number => typeof p === "number" && p > 0);
+
+	return resolved.length > 0 ? resolved.sort((a, b) => a - b) : null;
 };
 
 export function snapDescriptorToIndex(

--- a/packages/react-native-screen-transitions/src/shared/components/screen-container.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/screen-container.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: <Screen gesture is under the gesture context, so this will always exist.> */
 import { StackActions } from "@react-navigation/native";
 import { memo, useCallback } from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, useWindowDimensions, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated, { runOnUI, useAnimatedStyle } from "react-native-reanimated";
 import { DefaultSnapSpec } from "../configs/specs";
@@ -24,11 +24,19 @@ export const ScreenContainer = memo(({ children }: Props) => {
 	const { current } = useKeys();
 	const { pointerEvents, backdropBehavior } = useBackdropPointerEvents();
 	const gestureContext = useGestureContext();
+	const { height: screenHeight } = useWindowDimensions();
 
 	const BackdropComponent = current.options.backdropComponent;
 
 	const isBackdropActive =
 		backdropBehavior === "dismiss" || backdropBehavior === "collapse";
+
+	const routeKey = current.route.key;
+	const animations = AnimationStore.getAll(routeKey);
+	const autoSnapPointValue = animations.autoSnapPoint;
+
+	const hasAutoSnapPoint =
+		current.options.snapPoints?.includes("auto") ?? false;
 
 	const handleDismiss = useCallback(() => {
 		const state = current.navigation.getState();
@@ -46,24 +54,28 @@ export const ScreenContainer = memo(({ children }: Props) => {
 		}
 
 		if (backdropBehavior === "collapse") {
-			const snapPoints = current.options.snapPoints;
+			const rawSnapPoints = current.options.snapPoints;
 			const canDismiss = current.options.gestureEnabled !== false;
 
 			// No snap points → fallback to dismiss
-			if (!snapPoints || snapPoints.length === 0) {
+			if (!rawSnapPoints || rawSnapPoints.length === 0) {
 				handleDismiss();
 				return;
 			}
 
-			const animations = AnimationStore.getAll(current.route.key);
-			const gestures = GestureStore.getRouteGestures(current.route.key);
+			const gestures = GestureStore.getRouteGestures(routeKey);
 			const transitionSpec = current.options.transitionSpec;
 
 			runOnUI(() => {
 				"worklet";
+				// Resolve 'auto' snap points to numeric values inside the worklet
+				const resolvedSnaps = rawSnapPoints
+					.map((p) => (p === "auto" ? autoSnapPointValue.value : p))
+					.filter((p): p is number => typeof p === "number" && p > 0);
+
 				const { target, shouldDismiss } = findCollapseTarget(
 					animations.progress.value,
-					snapPoints,
+					resolvedSnaps,
 					canDismiss,
 				);
 
@@ -87,7 +99,52 @@ export const ScreenContainer = memo(({ children }: Props) => {
 				});
 			})();
 		}
-	}, [backdropBehavior, current, handleDismiss]);
+	}, [
+		backdropBehavior,
+		current,
+		handleDismiss,
+		routeKey,
+		animations,
+		autoSnapPointValue,
+	]);
+
+	// Measures the intrinsic content height when 'auto' is in snapPoints.
+	// Sets autoSnapPoint on the UI thread so worklets can reactively read it.
+	// If the open animation was deferred (progress still at 0), triggers it now.
+	const handleContentLayout = useCallback(
+		(event: { nativeEvent: { layout: { height: number } } }) => {
+			const contentHeight = event.nativeEvent.layout.height;
+			if (contentHeight <= 0) return;
+
+			const fraction = Math.min(contentHeight / screenHeight, 1);
+			const transitionSpec = current.options.transitionSpec;
+
+			runOnUI(() => {
+				"worklet";
+				const isFirstMeasurement = autoSnapPointValue.value <= 0;
+				autoSnapPointValue.value = fraction;
+
+				// If the screen was waiting for measurement before opening, animate now
+				if (
+					isFirstMeasurement &&
+					animations.progress.value === 0 &&
+					animations.animating.value === 0
+				) {
+					animateToProgress({
+						target: fraction,
+						spec: transitionSpec,
+						animations,
+					});
+				}
+			})();
+		},
+		[
+			screenHeight,
+			current.options.transitionSpec,
+			animations,
+			autoSnapPointValue,
+		],
+	);
 
 	const animatedContentStyle = useAnimatedStyle(() => {
 		"worklet";
@@ -121,7 +178,11 @@ export const ScreenContainer = memo(({ children }: Props) => {
 					style={[styles.content, animatedContentStyle]}
 					pointerEvents={isBackdropActive ? "box-none" : pointerEvents}
 				>
-					{children}
+					{hasAutoSnapPoint ? (
+						<View onLayout={handleContentLayout}>{children}</View>
+					) : (
+						children
+					)}
 				</Animated.View>
 			</GestureDetector>
 		</View>

--- a/packages/react-native-screen-transitions/src/shared/hooks/animation/use-screen-animation.tsx
+++ b/packages/react-native-screen-transitions/src/shared/hooks/animation/use-screen-animation.tsx
@@ -131,10 +131,23 @@ export function _useScreenAnimation() {
 	const currentRouteKey = currentDescriptor?.route?.key;
 	const currentIndex = routeKeys.indexOf(currentRouteKey);
 
-	const sortedSnapPoints = useMemo(() => {
+	const sortedNumericSnapPoints = useMemo(() => {
 		const points = currentDescriptor?.options?.snapPoints;
-		return points ? [...points].sort((a, b) => a - b) : [];
+		if (!points) return [];
+		return points
+			.filter((p): p is number => typeof p === "number")
+			.sort((a, b) => a - b);
 	}, [currentDescriptor?.options?.snapPoints]);
+
+	const hasAutoSnapPoint = useMemo(
+		() => currentDescriptor?.options?.snapPoints?.includes("auto") ?? false,
+		[currentDescriptor?.options?.snapPoints],
+	);
+
+	const autoSnapPointValue = AnimationStore.getAnimation(
+		currentRouteKey ?? "_",
+		"autoSnapPoint",
+	);
 
 	const nextRouteKey = nextDescriptor?.route?.key;
 	const nextHasTransitions =
@@ -169,7 +182,17 @@ export function _useScreenAnimation() {
 		const stackProgress =
 			currentIndex >= 0 ? rootStackProgress.value - currentIndex : progress;
 
-		const snapIndex = computeSnapIndex(current.progress, sortedSnapPoints);
+		// Resolve 'auto' snap point reactively so computeSnapIndex stays accurate
+		const resolvedAutoSnap =
+			hasAutoSnapPoint && autoSnapPointValue.value > 0
+				? autoSnapPointValue.value
+				: null;
+		const resolvedSnapPoints =
+			resolvedAutoSnap !== null
+				? [...sortedNumericSnapPoints, resolvedAutoSnap].sort((a, b) => a - b)
+				: sortedNumericSnapPoints;
+
+		const snapIndex = computeSnapIndex(current.progress, resolvedSnapPoints);
 
 		return {
 			layouts: { screen: dimensions },

--- a/packages/react-native-screen-transitions/src/shared/hooks/gestures/use-screen-gesture-handlers.ts
+++ b/packages/react-native-screen-transitions/src/shared/hooks/gestures/use-screen-gesture-handlers.ts
@@ -133,9 +133,22 @@ export const useScreenGestureHandlers = ({
 		gestureSnapLocked = false,
 	} = current.options;
 
-	const { hasSnapPoints, snapPoints, minSnapPoint, maxSnapPoint } = useMemo(
+	const {
+		hasSnapPoints,
+		hasAutoSnapPoint,
+		snapPoints,
+		minSnapPoint,
+		maxSnapPoint,
+	} = useMemo(
 		() => validateSnapPoints({ snapPoints: rawSnapPoints, canDismiss }),
 		[rawSnapPoints, canDismiss],
+	);
+
+	// SharedValue holding the resolved 'auto' fraction (-1 = not yet measured).
+	// Read inside worklets to get the latest value reactively.
+	const autoSnapPointValue = AnimationStore.getAnimation(
+		current.route.key,
+		"autoSnapPoint",
 	);
 
 	const directions = useMemo(() => {
@@ -331,9 +344,13 @@ export const useScreenGestureHandlers = ({
 							return;
 						}
 
+						const resolvedAutoMax =
+							hasAutoSnapPoint && autoSnapPointValue.value > 0
+								? Math.max(maxSnapPoint, autoSnapPointValue.value)
+								: maxSnapPoint;
 						const effectiveMaxSnapPoint = gestureSnapLocked
 							? lockedSnapPoint.value
-							: maxSnapPoint;
+							: resolvedAutoMax;
 
 						const canExpandMore =
 							animations.progress.value < effectiveMaxSnapPoint - EPSILON &&
@@ -354,12 +371,26 @@ export const useScreenGestureHandlers = ({
 
 	const onStart = useStableCallbackValue(() => {
 		"worklet";
+		// Resolve 'auto' snap point to its current measured value
+		const resolvedAuto =
+			hasAutoSnapPoint && autoSnapPointValue.value > 0
+				? autoSnapPointValue.value
+				: null;
+		const resolvedSnaps =
+			resolvedAuto !== null
+				? [...snapPoints, resolvedAuto].sort((a, b) => a - b)
+				: snapPoints;
+		const resolvedMax =
+			resolvedSnaps.length > 0
+				? resolvedSnaps[resolvedSnaps.length - 1]
+				: maxSnapPoint;
+
 		if (hasSnapPoints && gestureSnapLocked) {
-			let nearest = snapPoints[0] ?? animations.progress.value;
+			let nearest = resolvedSnaps[0] ?? animations.progress.value;
 			let smallestDistance = Math.abs(animations.progress.value - nearest);
 
-			for (let i = 1; i < snapPoints.length; i++) {
-				const point = snapPoints[i];
+			for (let i = 1; i < resolvedSnaps.length; i++) {
+				const point = resolvedSnaps[i];
 				const distance = Math.abs(animations.progress.value - point);
 				if (distance < smallestDistance) {
 					smallestDistance = distance;
@@ -369,7 +400,7 @@ export const useScreenGestureHandlers = ({
 
 			lockedSnapPoint.value = nearest;
 		} else {
-			lockedSnapPoint.value = maxSnapPoint;
+			lockedSnapPoint.value = resolvedMax;
 		}
 
 		gestureAnimationValues.isDragging.value = TRUE;
@@ -405,14 +436,32 @@ export const useScreenGestureHandlers = ({
 				const baseSign = -1;
 				const sign = directions.snapAxisInverted ? -baseSign : baseSign;
 				const progressDelta = (sign * translation) / dimension;
+
+				// Resolve 'auto' snap point bounds dynamically
+				const resolvedAutoVal =
+					hasAutoSnapPoint && autoSnapPointValue.value > 0
+						? autoSnapPointValue.value
+						: null;
+				const resolvedMax =
+					resolvedAutoVal !== null
+						? Math.max(maxSnapPoint, resolvedAutoVal)
+						: maxSnapPoint;
+				const resolvedMin =
+					resolvedAutoVal !== null && !canDismiss
+						? Math.min(
+								minSnapPoint === -1 ? resolvedAutoVal : minSnapPoint,
+								resolvedAutoVal,
+							)
+						: minSnapPoint;
+
 				const maxProgressForGesture = gestureSnapLocked
 					? lockedSnapPoint.value
-					: maxSnapPoint;
+					: resolvedMax;
 				const minProgressForGesture = gestureSnapLocked
 					? canDismiss
 						? 0
 						: lockedSnapPoint.value
-					: minSnapPoint;
+					: resolvedMin;
 
 				animations.progress.value = Math.max(
 					minProgressForGesture,
@@ -472,9 +521,21 @@ export const useScreenGestureHandlers = ({
 					? -axisVelocity
 					: axisVelocity;
 
+				// Resolve 'auto' into a numeric value for snap targeting
+				const resolvedAutoSnap =
+					hasAutoSnapPoint && autoSnapPointValue.value > 0
+						? autoSnapPointValue.value
+						: null;
+				const resolvedSnaps =
+					resolvedAutoSnap !== null
+						? [...snapPoints, resolvedAutoSnap].sort((a, b) => a - b)
+						: snapPoints;
+
 				const result = determineSnapTarget({
 					currentProgress: animations.progress.value,
-					snapPoints: gestureSnapLocked ? [lockedSnapPoint.value] : snapPoints,
+					snapPoints: gestureSnapLocked
+						? [lockedSnapPoint.value]
+						: resolvedSnaps,
 					velocity: snapVelocity,
 					dimension: axisDimension,
 					velocityFactor: snapVelocityImpact,

--- a/packages/react-native-screen-transitions/src/shared/hooks/lifecycle/use-open-transition.ts
+++ b/packages/react-native-screen-transitions/src/shared/hooks/lifecycle/use-open-transition.ts
@@ -1,19 +1,22 @@
 import { useLayoutEffect } from "react";
 import type { BaseDescriptor } from "../../providers/screen/keys.provider";
 import type { AnimationStoreMap } from "../../stores/animation.store";
+import type { SnapPoint } from "../../types/screen.types";
 import { animateToProgress } from "../../utils/animation/animate-to-progress";
 import { useHighRefreshRate } from "../animation/use-high-refresh-rate";
 
 /**
  * Calculates the initial progress value based on snap points configuration.
+ * Returns `'auto'` if the initial snap point is the `'auto'` keyword
+ * (meaning the animation must be deferred until content is measured).
  */
 function getInitialProgress({
 	snapPoints,
 	initialSnapIndex,
 }: {
-	snapPoints?: number[];
+	snapPoints?: SnapPoint[];
 	initialSnapIndex: number;
-}): number | undefined {
+}): number | "auto" | undefined {
 	if (!snapPoints) {
 		return undefined;
 	}
@@ -40,6 +43,12 @@ export function useOpenTransition(
 	useLayoutEffect(() => {
 		const { snapPoints, initialSnapIndex = 0 } = current.options;
 		const targetProgress = getInitialProgress({ snapPoints, initialSnapIndex });
+
+		// When the initial snap point is 'auto', defer the opening animation until
+		// ScreenContainer has measured the content and set autoSnapPoint.
+		if (targetProgress === "auto") {
+			return;
+		}
 
 		activateHighRefreshRate();
 		animateToProgress({

--- a/packages/react-native-screen-transitions/src/shared/stores/animation.store.ts
+++ b/packages/react-native-screen-transitions/src/shared/stores/animation.store.ts
@@ -7,6 +7,8 @@ export type AnimationStoreMap = {
 	closing: SharedValue<number>;
 	entering: SharedValue<number>;
 	targetProgress: SharedValue<number>;
+	/** Resolved fraction (contentHeight / screenHeight) for the 'auto' snap point. -1 = not yet measured. */
+	autoSnapPoint: SharedValue<number>;
 };
 
 const store: Record<ScreenKey, AnimationStoreMap> = {};
@@ -20,6 +22,7 @@ const ensure = (key: ScreenKey) => {
 			animating: makeMutable(0),
 			entering: makeMutable(1),
 			targetProgress: makeMutable(1),
+			autoSnapPoint: makeMutable(-1),
 		} satisfies AnimationStoreMap;
 		store[key] = bag;
 	}

--- a/packages/react-native-screen-transitions/src/shared/types/screen.types.ts
+++ b/packages/react-native-screen-transitions/src/shared/types/screen.types.ts
@@ -13,6 +13,12 @@ export type Layout = {
 
 export type ScreenKey = string;
 
+/**
+ * A single snap point value. Either a fraction of screen height (0–1) or
+ * `'auto'` to snap to the intrinsic height of the screen content.
+ */
+export type SnapPoint = number | "auto";
+
 export type TransitionAwareProps<T extends object> = AnimatedProps<T> & {
 	/**
 	 * Connects this component to custom animated styles defined in screenStyleInterpolator.
@@ -160,15 +166,21 @@ export type ScreenTransitionConfig = {
 	experimental_enableHighRefreshRate?: boolean;
 
 	/**
-	 * Describes heights where a screen can rest, as fractions of screen height.
-	 * Pass an array of ascending values from 0 to 1.
+	 * Describes heights where a screen can rest, as fractions of screen height,
+	 * or `'auto'` to snap to the intrinsic height of the screen content.
+	 *
+	 * Pass an array of ascending values from 0 to 1, or `'auto'`.
+	 * The `'auto'` value measures the content's natural height after layout and
+	 * converts it to the equivalent fraction of the screen height.
 	 *
 	 * @example
-	 * snapPoints={[0.5, 1.0]} // 50% and 100% of screen height
+	 * snapPoints={[0.5, 1.0]}     // 50% and 100% of screen height
+	 * snapPoints={['auto']}       // snap to content height
+	 * snapPoints={['auto', 1.0]}  // content height or full screen
 	 *
 	 * @default [1.0]
 	 */
-	snapPoints?: number[];
+	snapPoints?: SnapPoint[];
 
 	/**
 	 * The initial snap point index when the screen opens.

--- a/packages/react-native-screen-transitions/src/shared/utils/gesture/validate-snap-points.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/gesture/validate-snap-points.ts
@@ -1,12 +1,15 @@
+import type { SnapPoint } from "../../types/screen.types";
+
 interface ValidateSnapPointsResult {
 	hasSnapPoints: boolean;
+	hasAutoSnapPoint: boolean;
 	snapPoints: number[];
 	minSnapPoint: number;
 	maxSnapPoint: number;
 }
 
 interface ValidateSnapPointsOptions {
-	snapPoints?: number[];
+	snapPoints?: SnapPoint[];
 	canDismiss?: boolean;
 }
 
@@ -17,19 +20,28 @@ export const validateSnapPoints = ({
 	if (!snapPoints || snapPoints.length === 0) {
 		return {
 			hasSnapPoints: false,
+			hasAutoSnapPoint: false,
 			snapPoints: [],
 			minSnapPoint: -1,
 			maxSnapPoint: -1,
 		};
 	}
 
-	const normalizedSnaps = snapPoints.filter((point) =>
-		canDismiss ? Number.isFinite(point) : Number.isFinite(point) && point > 0,
+	const hasAuto = snapPoints.includes("auto");
+
+	const normalizedSnaps = snapPoints.filter(
+		(point): point is number =>
+			typeof point === "number" &&
+			(canDismiss
+				? Number.isFinite(point)
+				: Number.isFinite(point) && point > 0),
 	);
 
-	if (normalizedSnaps.length === 0) {
+	// hasSnapPoints is true if there are valid numeric points OR an 'auto' point
+	if (normalizedSnaps.length === 0 && !hasAuto) {
 		return {
 			hasSnapPoints: false,
+			hasAutoSnapPoint: false,
 			snapPoints: [],
 			minSnapPoint: -1,
 			maxSnapPoint: -1,
@@ -38,11 +50,12 @@ export const validateSnapPoints = ({
 
 	const sortedSnaps = normalizedSnaps.slice().sort((a, b) => a - b);
 	// Clamp to snap point bounds (dismiss at 0 only if allowed)
-	const minProgress = canDismiss ? 0 : sortedSnaps[0];
-	const maxProgress = sortedSnaps[sortedSnaps.length - 1];
+	const minProgress = canDismiss ? 0 : (sortedSnaps[0] ?? -1);
+	const maxProgress = sortedSnaps[sortedSnaps.length - 1] ?? -1;
 
 	return {
 		hasSnapPoints: true,
+		hasAutoSnapPoint: hasAuto,
 		snapPoints: sortedSnaps,
 		minSnapPoint: minProgress,
 		maxSnapPoint: maxProgress,


### PR DESCRIPTION
## Motivation
I wanted to have an auto snap point similar to `enableDynamicSizing` in `@gorhom/bottom-sheet`.

Tests run plus got claude to add some more tests for the auto scenario. e2e tests seem to be broken and don't run for me even before this PR so was not able to verify that.