### PR TITLE
fix: isolate scroll axis writes in useScrollRegistry

### DIFF
--- a/packages/react-native-screen-transitions/src/shared/hooks/gestures/use-scroll-registry.tsx
+++ b/packages/react-native-screen-transitions/src/shared/hooks/gestures/use-scroll-registry.tsx
@@ -156,6 +156,8 @@ export const useScrollRegistry = (props: ScrollProgressHookProps) => {
 		return gesture;
 	}, [panGestures, scrollConfigs]);
 
+	const isHorizontal = scrollDirection === "horizontal";
+
 	const scrollHandler = useAnimatedScrollHandler({
 		onScroll: (event) => {
 			if (scrollConfigs.length === 0) return;
@@ -164,8 +166,8 @@ export const useScrollRegistry = (props: ScrollProgressHookProps) => {
 				"worklet";
 				if (v === null) {
 					return {
-						x: event.contentOffset.x,
-						y: event.contentOffset.y,
+						x: isHorizontal ? event.contentOffset.x : 0,
+						y: isHorizontal ? 0 : event.contentOffset.y,
 						contentHeight: 0,
 						contentWidth: 0,
 						layoutHeight: 0,
@@ -173,8 +175,11 @@ export const useScrollRegistry = (props: ScrollProgressHookProps) => {
 						isTouched: true,
 					};
 				}
-				v.x = event.contentOffset.x;
-				v.y = event.contentOffset.y;
+				if (isHorizontal) {
+					v.x = event.contentOffset.x;
+				} else {
+					v.y = event.contentOffset.y;
+				}
 				return v;
 			};
 
@@ -198,13 +203,16 @@ export const useScrollRegistry = (props: ScrollProgressHookProps) => {
 						y: 0,
 						layoutHeight: 0,
 						layoutWidth: 0,
-						contentWidth: width,
-						contentHeight: height,
+						contentWidth: isHorizontal ? width : 0,
+						contentHeight: isHorizontal ? 0 : height,
 						isTouched: false,
 					};
 				}
-				v.contentWidth = width;
-				v.contentHeight = height;
+				if (isHorizontal) {
+					v.contentWidth = width;
+				} else {
+					v.contentHeight = height;
+				}
 				return v;
 			};
 
@@ -229,13 +237,16 @@ export const useScrollRegistry = (props: ScrollProgressHookProps) => {
 					y: 0,
 					contentHeight: 0,
 					contentWidth: 0,
-					layoutHeight: height,
-					layoutWidth: width,
+					layoutHeight: isHorizontal ? 0 : height,
+					layoutWidth: isHorizontal ? width : 0,
 					isTouched: false,
 				};
 			}
-			v.layoutHeight = height;
-			v.layoutWidth = width;
+			if (isHorizontal) {
+				v.layoutWidth = width;
+			} else {
+				v.layoutHeight = height;
+			}
 			return v;
 		};
 


### PR DESCRIPTION
Fixes #84

## Motivation

When a screen contains nested `Transition.ScrollView` components on different axes — for example, a horizontal pager wrapping multiple vertical scrollable sections — all ScrollView instances write to the **same shared `scrollConfig`** owned by the screen's gesture context.

Previously, every ScrollView unconditionally wrote **both** `x` and `y` offsets, along with `contentWidth`/`contentHeight` and `layoutWidth`/`layoutHeight`, on every scroll, layout, and content-size event. This meant that a vertical ScrollView would overwrite `scrollX` to `0`, and a horizontal ScrollView would overwrite `scrollY` to `0`, regardless of the actual scroll state of the other axis.

In the reported scenario:

1. A detail screen opens as an interactive sheet with a horizontal `Transition.ScrollView` (pager) containing 5 vertically scrollable sections.
2. The user scrolls vertically in any section, setting `scrollY = 150` in the shared config.
3. The user then swipes horizontally to back to previously section.
4. The horizontal ScrollView fires a scroll event and resets `scrollY` back to `0` (since its own `contentOffset.y` is always `0`).
5. The gesture system's `checkScrollBoundary` evaluates the `"vertical"` direction, sees `scrollY <= 0`, and incorrectly concludes the scroll is at its top boundary.
6. The dismiss gesture activates instead of allowing horizontal paging, unexpectedly closing the screen.

This affects **all sections**. Any section where the user scrolls vertically and then immediately swipes horizontally can trigger the dismiss.

## Changes

Isolate scroll data writes in `useScrollRegistry` by axis:

- **Horizontal ScrollViews** only write `x`, `contentWidth`, and `layoutWidth`
- **Vertical ScrollViews** only write `y`, `contentHeight`, and `layoutHeight`
- Cross-axis fields are zeroed on initialization and left untouched during updates, preventing one axis from overwriting the other

The `isHorizontal` flag is derived from the `direction` prop (which maps to the ScrollView's `horizontal` prop) at render time. This value is immutable for the lifetime of a ScrollView instance, so capturing it in the handler closures is safe.