### PR TITLE
Fix bounds worklet imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"lint": "biome check packages/react-native-screen-transitions/src",
 		"typecheck": "tsc -p packages/react-native-screen-transitions/tsconfig.typecheck.json",
 		"release": "bun run release:stable",
+		"release:patch": "bun run --cwd packages/react-native-screen-transitions release:patch",
 		"release:stable": "bun run --cwd packages/react-native-screen-transitions release:stable",
 		"release:beta": "bun run --cwd packages/react-native-screen-transitions release:beta",
 		"release:alpha": "bun run --cwd packages/react-native-screen-transitions release:alpha",
@@ -28,6 +29,7 @@
 		"release:beta:dry-run": "bun run --cwd packages/react-native-screen-transitions release:beta:dry-run",
 		"release:rc:dry-run": "bun run --cwd packages/react-native-screen-transitions release:rc:dry-run",
 		"release:react-native-screen-transitions": "bun run release:stable",
+		"release:react-native-screen-transitions:patch": "bun run release:patch",
 		"release:react-native-screen-transitions:beta": "bun run release:beta"
 	},
 	"devDependencies": {

--- a/packages/react-native-screen-transitions/package.json
+++ b/packages/react-native-screen-transitions/package.json
@@ -45,6 +45,7 @@
 		"typecheck": "tsc -p tsconfig.typecheck.json",
 		"prepublishOnly": "bun run build",
 		"release": "release-it",
+		"release:patch": "release-it patch",
 		"release:stable": "release-it",
 		"release:beta": "release-it --preRelease=beta",
 		"release:alpha": "release-it --preRelease=alpha",

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/create-boundary-component.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/create-boundary-component.tsx
@@ -15,7 +15,7 @@ import Animated, {
 import { NO_STYLES } from "../../constants";
 import { useDescriptorDerivations } from "../../providers/screen/descriptors";
 import { useScreenStyles } from "../../providers/screen/styles";
-import { BoundStore } from "../../stores/bounds";
+import { setGroupActiveId } from "../../stores/bounds/internals/groups";
 import { prepareStyleForBounds } from "../../utils/bounds/helpers/styles/styles";
 import { useBoundaryPresence } from "./hooks/use-boundary-presence";
 import { useCaptureDestinationBoundary } from "./hooks/use-capture-destination-boundary";
@@ -183,7 +183,7 @@ export function createBoundaryComponent<P extends object>(
 			(...args: unknown[]) => {
 				// Press path has priority: capture source before user onPress/navigation.
 				if (group) {
-					runOnUI(BoundStore.group.setActiveId)(group, String(id));
+					runOnUI(setGroupActiveId)(group, String(id));
 				}
 				runOnUI(measureBoundary)({ intent: "capture-source" });
 

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/helpers/resolve-pending-source-key.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/helpers/resolve-pending-source-key.ts
@@ -1,4 +1,7 @@
-import { BoundStore } from "../../../stores/bounds";
+import {
+	getPendingLink,
+	hasSourceLink,
+} from "../../../stores/bounds/internals/registry";
 
 export const resolvePendingSourceKey = (
 	sharedBoundTag: string,
@@ -7,11 +10,11 @@ export const resolvePendingSourceKey = (
 	"worklet";
 	if (
 		expectedSourceScreenKey &&
-		(BoundStore.link.getPending(sharedBoundTag, expectedSourceScreenKey) ||
-			BoundStore.link.hasSource(sharedBoundTag, expectedSourceScreenKey))
+		(getPendingLink(sharedBoundTag, expectedSourceScreenKey) ||
+			hasSourceLink(sharedBoundTag, expectedSourceScreenKey))
 	) {
 		return expectedSourceScreenKey;
 	}
 
-	return BoundStore.link.getPending(sharedBoundTag)?.source.screenKey ?? null;
+	return getPendingLink(sharedBoundTag)?.source.screenKey ?? null;
 };

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-boundary-presence.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-boundary-presence.ts
@@ -1,6 +1,9 @@
 import { useLayoutEffect } from "react";
 import { runOnUI } from "react-native-reanimated";
-import { BoundStore } from "../../../stores/bounds";
+import {
+	removeEntry,
+	setEntry,
+} from "../../../stores/bounds/internals/registry";
 import type { BoundaryConfigProps } from "../types";
 
 export const useBoundaryPresence = (params: {
@@ -28,7 +31,7 @@ export const useBoundaryPresence = (params: {
 	useLayoutEffect(() => {
 		if (!enabled) return;
 
-		runOnUI(BoundStore.entry.set)(sharedBoundTag, currentScreenKey, {
+		runOnUI(setEntry)(sharedBoundTag, currentScreenKey, {
 			ancestorKeys,
 			boundaryConfig,
 			navigatorKey,
@@ -36,7 +39,7 @@ export const useBoundaryPresence = (params: {
 		});
 
 		return () => {
-			runOnUI(BoundStore.entry.remove)(sharedBoundTag, currentScreenKey);
+			runOnUI(removeEntry)(sharedBoundTag, currentScreenKey);
 		};
 	}, [
 		enabled,

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-capture-destination-boundary.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-capture-destination-boundary.ts
@@ -8,7 +8,12 @@ import {
 	withTiming,
 } from "react-native-reanimated";
 import { AnimationStore } from "../../../stores/animation.store";
-import { BoundStore } from "../../../stores/bounds";
+import { getGroupActiveId } from "../../../stores/bounds/internals/groups";
+import {
+	getPendingLink,
+	hasDestinationLink,
+	hasSourceLink,
+} from "../../../stores/bounds/internals/registry";
 import { SystemStore } from "../../../stores/system.store";
 import { resolvePendingSourceKey } from "../helpers/resolve-pending-source-key";
 import type { BoundaryId, MeasureParams } from "../types";
@@ -88,10 +93,10 @@ export const useCaptureDestinationBoundary = ({
 				expectedSourceScreenKey,
 			);
 			const hasAttachableSourceLink = resolvedSourceKey
-				? BoundStore.link.getPending(sharedBoundTag, resolvedSourceKey) !==
-						null || BoundStore.link.hasSource(sharedBoundTag, resolvedSourceKey)
+				? getPendingLink(sharedBoundTag, resolvedSourceKey) !== null ||
+					hasSourceLink(sharedBoundTag, resolvedSourceKey)
 				: false;
-			const hasDestinationLink = BoundStore.link.hasDestination(
+			const hasDestination = hasDestinationLink(
 				sharedBoundTag,
 				currentScreenKey,
 			);
@@ -100,13 +105,13 @@ export const useCaptureDestinationBoundary = ({
 				enabled &&
 				!!resolvedSourceKey &&
 				hasAttachableSourceLink &&
-				!hasDestinationLink;
+				!hasDestination;
 
 			if (!shouldBlock) {
 				return [0, retryTick] as const;
 			}
 
-			if (group && BoundStore.group.getActiveId(group) !== String(id)) {
+			if (group && getGroupActiveId(group) !== String(id)) {
 				return [0, retryTick] as const;
 			}
 
@@ -122,7 +127,7 @@ export const useCaptureDestinationBoundary = ({
 			ensureLifecycleStartBlocked();
 			measureBoundary({ intent: "complete-destination" });
 
-			if (BoundStore.link.hasDestination(sharedBoundTag, currentScreenKey)) {
+			if (hasDestinationLink(sharedBoundTag, currentScreenKey)) {
 				releaseLifecycleStartBlock();
 				return;
 			}

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-capture-source-boundary.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-capture-source-boundary.ts
@@ -1,5 +1,5 @@
 import { useAnimatedReaction } from "react-native-reanimated";
-import { BoundStore } from "../../../stores/bounds";
+import { getGroupActiveId } from "../../../stores/bounds/internals/groups";
 import type { BoundaryId, MeasureParams } from "../types";
 
 export const useCaptureSourceBoundary = (params: {
@@ -27,9 +27,7 @@ export const useCaptureSourceBoundary = (params: {
 			if (!nextScreenKey) return;
 			if (!captureSignal || captureSignal === previousCaptureSignal) return;
 
-			const currentGroupActiveId = group
-				? BoundStore.group.getActiveId(group)
-				: null;
+			const currentGroupActiveId = group ? getGroupActiveId(group) : null;
 
 			if (group && currentGroupActiveId !== String(id)) {
 				return;

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-measurer.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-measurer.ts
@@ -6,8 +6,13 @@ import {
 	measure,
 	type StyleProps,
 } from "react-native-reanimated";
-import { BoundStore } from "../../../stores/bounds";
 import { applyMeasuredBoundsWrites } from "../../../stores/bounds/helpers/apply-measured-bounds-writes";
+import {
+	getMeasuredEntry,
+	getPendingLink,
+	hasDestinationLink,
+	hasSourceLink,
+} from "../../../stores/bounds/internals/registry";
 import { resolvePendingSourceKey } from "../helpers/resolve-pending-source-key";
 import type { MeasureParams } from "../types";
 import {
@@ -57,17 +62,14 @@ export const useMeasurer = ({
 				undefined;
 
 			const pendingLink = expectedSourceScreenKey
-				? BoundStore.link.getPending(sharedBoundTag, expectedSourceScreenKey)
-				: BoundStore.link.getPending(sharedBoundTag);
+				? getPendingLink(sharedBoundTag, expectedSourceScreenKey)
+				: getPendingLink(sharedBoundTag);
 			const hasPendingLink = pendingLink !== null;
 			const hasAttachableSourceLink = expectedSourceScreenKey
-				? BoundStore.link.hasSource(sharedBoundTag, expectedSourceScreenKey)
+				? hasSourceLink(sharedBoundTag, expectedSourceScreenKey)
 				: false;
-			const hasSourceLink = BoundStore.link.hasSource(
-				sharedBoundTag,
-				currentScreenKey,
-			);
-			const hasDestinationLink = BoundStore.link.hasDestination(
+			const hasSource = hasSourceLink(sharedBoundTag, currentScreenKey);
+			const hasDestination = hasDestinationLink(
 				sharedBoundTag,
 				currentScreenKey,
 			);
@@ -75,8 +77,8 @@ export const useMeasurer = ({
 			const writePlan = resolveMeasureWritePlan({
 				intents,
 				hasPendingLink,
-				hasSourceLink,
-				hasDestinationLink,
+				hasSourceLink: hasSource,
+				hasDestinationLink: hasDestination,
 				hasAttachableSourceLink,
 			});
 
@@ -99,7 +101,7 @@ export const useMeasurer = ({
 				return;
 			}
 
-			const existingMeasuredEntry = BoundStore.entry.getMeasured(
+			const existingMeasuredEntry = getMeasuredEntry(
 				sharedBoundTag,
 				currentScreenKey,
 			);

--- a/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-refresh-boundary.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/create-boundary-component/hooks/use-refresh-boundary.ts
@@ -1,6 +1,7 @@
 import { useAnimatedReaction } from "react-native-reanimated";
 import { AnimationStore } from "../../../stores/animation.store";
-import { BoundStore } from "../../../stores/bounds";
+import { getGroupActiveId } from "../../../stores/bounds/internals/groups";
+import { hasSourceLink } from "../../../stores/bounds/internals/registry";
 import { GestureStore } from "../../../stores/gesture.store";
 import type { BoundaryId, MeasureParams } from "../types";
 
@@ -51,9 +52,7 @@ export const useRefreshBoundary = ({
 			if (!enabled || !hasNextScreen) return;
 			if (nextValue === 0 || nextValue === previousValue) return;
 
-			const currentGroupActiveId = group
-				? BoundStore.group.getActiveId(group)
-				: null;
+			const currentGroupActiveId = group ? getGroupActiveId(group) : null;
 
 			if (group && currentGroupActiveId !== String(id)) {
 				return;
@@ -66,12 +65,9 @@ export const useRefreshBoundary = ({
 				return;
 			}
 
-			const hasSourceLink = BoundStore.link.hasSource(
-				sharedBoundTag,
-				currentScreenKey,
-			);
+			const hasSource = hasSourceLink(sharedBoundTag, currentScreenKey);
 
-			const intent = !hasSourceLink
+			const intent = !hasSource
 				? "capture-source"
 				: group
 					? "refresh-source"
@@ -92,9 +88,7 @@ export const useRefreshBoundary = ({
 			if (!enabled || hasNextScreen) return;
 			if (nextValue === 0 || nextValue === previousValue) return;
 
-			const currentGroupActiveId = group
-				? BoundStore.group.getActiveId(group)
-				: null;
+			const currentGroupActiveId = group ? getGroupActiveId(group) : null;
 
 			if (group && currentGroupActiveId !== String(id)) {
 				return;

--- a/packages/react-native-screen-transitions/src/shared/components/screen-lifecycle/hooks/helpers/reset-stores-for-screen.ts
+++ b/packages/react-native-screen-transitions/src/shared/components/screen-lifecycle/hooks/helpers/reset-stores-for-screen.ts
@@ -1,6 +1,10 @@
 import { runOnUI } from "react-native-reanimated";
 import { AnimationStore } from "../../../../stores/animation.store";
-import { BoundStore } from "../../../../stores/bounds";
+import {
+	clear,
+	clearByAncestor,
+	clearByBranch,
+} from "../../../../stores/bounds/internals/clear";
 import { GestureStore } from "../../../../stores/gesture.store";
 import { SystemStore } from "../../../../stores/system.store";
 
@@ -17,13 +21,13 @@ export function resetStoresForScreen(
 		"worklet";
 		if (!isBranchScreen) return;
 
-		BoundStore.cleanup.byScreen(routeKey);
+		clear(routeKey);
 
 		if (branchNavigatorKey) {
-			BoundStore.cleanup.byBranch(branchNavigatorKey);
+			clearByBranch(branchNavigatorKey);
 			return;
 		}
 
-		BoundStore.cleanup.byAncestor(routeKey);
+		clearByAncestor(routeKey);
 	})();
 }

--- a/packages/react-native-screen-transitions/src/shared/providers/register-bounds.provider.tsx
+++ b/packages/react-native-screen-transitions/src/shared/providers/register-bounds.provider.tsx
@@ -14,8 +14,13 @@ import type { SharedValue } from "react-native-reanimated/lib/typescript/commonT
 import useStableCallback from "../hooks/use-stable-callback";
 import useStableCallbackValue from "../hooks/use-stable-callback-value";
 import { AnimationStore } from "../stores/animation.store";
-import { BoundStore } from "../stores/bounds";
 import { applyMeasuredBoundsWrites } from "../stores/bounds/helpers/apply-measured-bounds-writes";
+import {
+	getMeasuredEntry,
+	getPendingLink,
+	hasDestinationLink,
+	hasSourceLink,
+} from "../stores/bounds/internals/registry";
 import { prepareStyleForBounds } from "../utils/bounds/helpers/styles/styles";
 import createProvider from "../utils/create-provider";
 import { useDescriptorDerivations, useDescriptors } from "./screen/descriptors";
@@ -276,10 +281,7 @@ const registerBoundsBundle = createProvider("RegisterBounds", {
 				}
 
 				if (shouldSetSource && isAnimating.get()) {
-					const existing = BoundStore.entry.getMeasured(
-						sharedBoundTag,
-						currentScreenKey,
-					);
+					const existing = getMeasuredEntry(sharedBoundTag, currentScreenKey);
 					if (existing) {
 						applyMeasuredBoundsWrites({
 							sharedBoundTag,
@@ -297,13 +299,9 @@ const registerBoundsBundle = createProvider("RegisterBounds", {
 					return;
 				}
 
-				const hasPendingLink =
-					BoundStore.link.getPending(sharedBoundTag) !== null;
-				const hasSourceLink = BoundStore.link.hasSource(
-					sharedBoundTag,
-					currentScreenKey,
-				);
-				const hasDestinationLink = BoundStore.link.hasDestination(
+				const hasPending = getPendingLink(sharedBoundTag) !== null;
+				const hasSource = hasSourceLink(sharedBoundTag, currentScreenKey);
+				const hasDestination = hasDestinationLink(
 					sharedBoundTag,
 					currentScreenKey,
 				);
@@ -315,11 +313,10 @@ const registerBoundsBundle = createProvider("RegisterBounds", {
 					!wantsSetSource && !wantsSetDestination && !wantsUpdateSource;
 
 				const canSetSource = wantsSetSource;
-				const canSetDestination = wantsSetDestination && hasPendingLink;
-				const canUpdateSource = wantsUpdateSource && hasSourceLink;
+				const canSetDestination = wantsSetDestination && hasPending;
+				const canUpdateSource = wantsUpdateSource && hasSource;
 				const canSnapshotOnly =
-					wantsSnapshotOnly &&
-					(hasPendingLink || hasSourceLink || hasDestinationLink);
+					wantsSnapshotOnly && (hasPending || hasSource || hasDestination);
 
 				if (
 					!canSetSource &&

--- a/packages/react-native-screen-transitions/src/shared/stores/bounds/helpers/apply-measured-bounds-writes.ts
+++ b/packages/react-native-screen-transitions/src/shared/stores/bounds/helpers/apply-measured-bounds-writes.ts
@@ -1,5 +1,5 @@
 import type { MeasuredDimensions, StyleProps } from "react-native-reanimated";
-import { BoundStore } from "..";
+import { setDestination, setEntry, setSource } from "../internals/registry";
 
 type ApplyMeasuredBoundsWritesParams = {
 	sharedBoundTag: string;
@@ -38,7 +38,7 @@ export const applyMeasuredBoundsWrites = (
 	} = params;
 
 	if (shouldWriteEntry) {
-		BoundStore.entry.set(sharedBoundTag, currentScreenKey, {
+		setEntry(sharedBoundTag, currentScreenKey, {
 			bounds: measured,
 			styles: preparedStyles,
 			ancestorKeys,
@@ -48,7 +48,7 @@ export const applyMeasuredBoundsWrites = (
 	}
 
 	if (shouldSetSource) {
-		BoundStore.link.setSource(
+		setSource(
 			"capture",
 			sharedBoundTag,
 			currentScreenKey,
@@ -61,7 +61,7 @@ export const applyMeasuredBoundsWrites = (
 	}
 
 	if (shouldUpdateSource) {
-		BoundStore.link.setSource(
+		setSource(
 			"refresh",
 			sharedBoundTag,
 			currentScreenKey,
@@ -74,7 +74,7 @@ export const applyMeasuredBoundsWrites = (
 	}
 
 	if (shouldUpdateDestination) {
-		BoundStore.link.setDestination(
+		setDestination(
 			"refresh",
 			sharedBoundTag,
 			currentScreenKey,
@@ -88,7 +88,7 @@ export const applyMeasuredBoundsWrites = (
 	}
 
 	if (shouldSetDestination) {
-		BoundStore.link.setDestination(
+		setDestination(
 			"attach",
 			sharedBoundTag,
 			currentScreenKey,

--- a/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/create-interpolators.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/create-interpolators.ts
@@ -4,7 +4,7 @@ import {
 	type MeasuredDimensions,
 } from "react-native-reanimated";
 import { ENTER_RANGE, EXIT_RANGE } from "../../../constants";
-import { BoundStore } from "../../../stores/bounds";
+import { getMeasuredEntry } from "../../../stores/bounds/internals/registry";
 import type { ScreenInterpolationProps } from "../../../types/animation.types";
 import type { BoundId } from "../types/options";
 import type { LinkAccessor } from "./create-link-accessor";
@@ -51,12 +51,9 @@ export const createInterpolators = ({
 		const normalizedTag = String(tag);
 
 		const currentMeasuredEntry = currentKey
-			? BoundStore.entry.getMeasured(normalizedTag, currentKey)
+			? getMeasuredEntry(normalizedTag, currentKey)
 			: null;
-		const targetMeasuredEntry = BoundStore.entry.getMeasured(
-			normalizedTag,
-			targetKey,
-		);
+		const targetMeasuredEntry = getMeasuredEntry(normalizedTag, targetKey);
 
 		const currentValue = currentMeasuredEntry?.bounds?.[property] ?? fb;
 		const targetValue = targetMeasuredEntry?.bounds?.[property] ?? fb;

--- a/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/create-link-accessor.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/create-link-accessor.ts
@@ -1,4 +1,8 @@
-import { BoundStore, type MeasuredEntry } from "../../../stores/bounds";
+import {
+	getActiveLink,
+	getMeasuredEntry,
+} from "../../../stores/bounds/internals/registry";
+import type { MeasuredEntry } from "../../../stores/bounds/types";
 import type { ScreenInterpolationProps } from "../../../types/animation.types";
 import type { BoundsLink } from "../../../types/bounds.types";
 import type { BoundId } from "../types/options";
@@ -17,7 +21,7 @@ export const createLinkAccessor = (getProps: GetProps): LinkAccessor => {
 	const getMeasured = (tag: BoundId, key?: string): MeasuredEntry | null => {
 		"worklet";
 		if (!key) return null;
-		return BoundStore.entry.getMeasured(String(tag), key);
+		return getMeasuredEntry(String(tag), key);
 	};
 
 	const getSnapshot = (tag: BoundId, key?: string): MeasuredEntry | null => {
@@ -28,10 +32,7 @@ export const createLinkAccessor = (getProps: GetProps): LinkAccessor => {
 	const getLink = (tag: BoundId): BoundsLink | null => {
 		"worklet";
 		const props = getProps();
-		const link = BoundStore.link.getActive(
-			String(tag),
-			props.current?.route.key,
-		);
+		const link = getActiveLink(String(tag), props.current?.route.key);
 		if (!link) return null;
 		return {
 			source: link.source

--- a/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/prepare-bound-styles.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/prepare-bound-styles.ts
@@ -1,7 +1,9 @@
 import {
-	BoundStore,
-	type ResolvedTransitionPair,
-} from "../../../stores/bounds";
+	getGroupActiveId,
+	setGroupActiveId,
+} from "../../../stores/bounds/internals/groups";
+import { getEntryConfig } from "../../../stores/bounds/internals/registry";
+import type { ResolvedTransitionPair } from "../../../stores/bounds/types";
 import type { ScreenInterpolationProps } from "../../../types/animation.types";
 import { DEFAULT_BOUNDS_OPTIONS } from "../constants";
 import type {
@@ -40,9 +42,7 @@ export const buildBoundsOptions = ({
 	const currentScreenKey = props.current?.route.key;
 
 	const boundaryConfig =
-		tag && currentScreenKey
-			? BoundStore.entry.getConfig(tag, currentScreenKey)
-			: null;
+		tag && currentScreenKey ? getEntryConfig(tag, currentScreenKey) : null;
 
 	const resolved = {
 		...DEFAULT_BOUNDS_OPTIONS,
@@ -61,9 +61,9 @@ const syncGroupActiveMember = (group?: string, id?: BoundId) => {
 
 	const normalizedId = String(id);
 
-	if (BoundStore.group.getActiveId(group) === normalizedId) return;
+	if (getGroupActiveId(group) === normalizedId) return;
 
-	BoundStore.group.setActiveId(group, normalizedId);
+	setGroupActiveId(group, normalizedId);
 };
 
 export const prepareBoundStyles = <T extends BoundsOptions>({

--- a/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/styles/compute.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/bounds/helpers/styles/compute.ts
@@ -5,10 +5,8 @@ import {
 	FULLSCREEN_DIMENSIONS,
 	NO_STYLES,
 } from "../../../../constants";
-import {
-	BoundStore,
-	type ResolvedTransitionPair,
-} from "../../../../stores/bounds";
+import { resolveTransitionPair } from "../../../../stores/bounds/internals/resolver";
+import type { ResolvedTransitionPair } from "../../../../stores/bounds/types";
 import type { ScreenTransitionState } from "../../../../types/animation.types";
 import type { Layout } from "../../../../types/screen.types";
 import type {
@@ -54,7 +52,7 @@ const resolveStartEnd = (params: {
 
 	const resolvedPair =
 		params.resolvedPair ??
-		BoundStore.link.getPair(String(params.id), {
+		resolveTransitionPair(String(params.id), {
 			currentScreenKey,
 			previousScreenKey,
 			nextScreenKey,

--- a/packages/react-native-screen-transitions/src/shared/utils/bounds/zoom/build.ts
+++ b/packages/react-native-screen-transitions/src/shared/utils/bounds/zoom/build.ts
@@ -5,10 +5,9 @@ import {
 	NAVIGATION_MASK_ELEMENT_STYLE_ID,
 	VISIBLE_STYLE,
 } from "../../../constants";
-import {
-	BoundStore,
-	type ResolvedTransitionPair,
-} from "../../../stores/bounds";
+import { getGroupActiveId } from "../../../stores/bounds/internals/groups";
+import { resolveTransitionPair } from "../../../stores/bounds/internals/resolver";
+import type { ResolvedTransitionPair } from "../../../stores/bounds/types";
 import type { TransitionInterpolatedStyle } from "../../../types/animation.types";
 import type { Layout } from "../../../types/screen.types";
 import { prepareBoundStyles } from "../helpers/prepare-bound-styles";
@@ -176,7 +175,7 @@ export function buildZoomStyles({
 	let buildEffectiveTag = tag;
 	if (isGroup) {
 		const group = tag.split(":")[0];
-		const groupActiveTag = BoundStore.group.getActiveId(group)?.split(":")[0];
+		const groupActiveTag = getGroupActiveId(group)?.split(":")[0];
 		buildEffectiveTag = `${group}:${groupActiveTag ?? tag.split(":")[1]}`;
 	}
 
@@ -201,7 +200,7 @@ export function buildZoomStyles({
 		scaleMode: ZOOM_SHARED_OPTIONS.scaleMode,
 	} as const;
 
-	const linkPair = BoundStore.link.getPair(buildEffectiveTag, {
+	const linkPair = resolveTransitionPair(buildEffectiveTag, {
 		currentScreenKey: currentRouteKey,
 		previousScreenKey: previousRouteKey,
 		nextScreenKey: nextRouteKey,


### PR DESCRIPTION
## Summary

- Replace `BoundStore` facade usage in bounds worklet paths with direct registry, group, clear, and resolver imports.
- Keep the `BoundStore` facade available for tests and normal JS-thread orchestration.
- Avoid capturing nested facade properties in Reanimated UI-runtime functions.

## Why

Bloom exposed a UI-runtime initialization edge case where the aggregate `BoundStore` facade could be undefined or partially initialized when a worklet was evaluated. Direct imports keep worklet code bound to the actual worklet-safe functions instead of a plain JS facade object assembled through the bounds barrel.

## Validation

- `bun test packages/react-native-screen-transitions/src/shared/__tests__`
- `bun run lint`
- `bunx tsc -p packages/react-native-screen-transitions/tsconfig.typecheck.json --ignoreDeprecations 6.0`