### PR TITLE
Release 3.5.1

### DIFF
--- a/packages/react-native-screen-transitions/CHANGELOG.md
+++ b/packages/react-native-screen-transitions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.5.1](https://github.com/eds2002/react-native-screen-transitions/compare/v3.5.0...v3.5.1) (2026-05-05)
+
+
+### Bug Fixes
+
+* fix bounds worklet imports ([#94](https://github.com/eds2002/react-native-screen-transitions/issues/94)) ([6260b8f](https://github.com/eds2002/react-native-screen-transitions/commit/6260b8fd0669096ef764476abe7b18dc1ff9a1c0))
+
 # [3.5.0](https://github.com/eds2002/react-native-screen-transitions/compare/v3.5.0-beta.0...v3.5.0) (2026-04-26)
 
 # [3.5.0-beta.0](https://github.com/eds2002/react-native-screen-transitions/compare/v3.2.0...v3.5.0-beta.0) (2026-04-21)

--- a/packages/react-native-screen-transitions/package.json
+++ b/packages/react-native-screen-transitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-screen-transitions",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "Easy screen transitions for React Native and Expo",
 	"author": "Ed",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- Bump `react-native-screen-transitions` to `3.5.1`.
- Add the `3.5.1` changelog entry for the bounds worklet import fix.

## Notes

The package has already been published to npm as `react-native-screen-transitions@3.5.1`. This PR brings the release commit back into `main` so the repository state matches the published package.

After this PR lands, retag `v3.5.1` to the final `main` commit so future changelogs can use `v3.5.1` as the base.