### PR TITLE
chore: add prerelease channels

### DIFF
--- a/.github/scripts/resolve-prerelease-version.mjs
+++ b/.github/scripts/resolve-prerelease-version.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const packageDir =
+	process.env.PACKAGE_DIR ?? "packages/react-native-screen-transitions";
+const channel = readRequiredEnv("PRERELEASE_CHANNEL");
+const bump = process.env.PRERELEASE_BUMP ?? "patch";
+
+const allowedChannels = new Set(["alpha", "beta", "rc"]);
+const allowedBumps = new Set(["patch", "minor", "major"]);
+
+if (!allowedChannels.has(channel)) {
+	throw new Error(
+		`Unsupported prerelease channel "${channel}". Expected alpha, beta, or rc.`,
+	);
+}
+
+if (!allowedBumps.has(bump)) {
+	throw new Error(
+		`Unsupported prerelease bump "${bump}". Expected patch, minor, or major.`,
+	);
+}
+
+const packageJsonPath = resolve(process.cwd(), packageDir, "package.json");
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const stableVersion = parseStableVersion(packageJson.version);
+const baseVersion = bumpVersion(stableVersion, bump);
+const publishedVersions = readPublishedVersions(packageJson.name);
+const prefix = `${baseVersion.major}.${baseVersion.minor}.${baseVersion.patch}-${channel}.`;
+const nextPrerelease = nextPrereleaseNumber(publishedVersions, prefix);
+const version = `${prefix}${nextPrerelease}`;
+
+writeOutput("version", version);
+writeOutput("tag", `v${version}`);
+writeOutput("npm_tag", channel);
+
+console.log(
+	JSON.stringify(
+		{
+			package: packageJson.name,
+			currentVersion: packageJson.version,
+			bump,
+			channel,
+			version,
+			npmTag: channel,
+		},
+		null,
+		2,
+	),
+);
+
+function readRequiredEnv(name) {
+	const value = process.env[name];
+
+	if (!value) {
+		throw new Error(`Missing required environment variable ${name}.`);
+	}
+
+	return value;
+}
+
+function parseStableVersion(version) {
+	const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+
+	if (!match) {
+		throw new Error(
+			`Expected package.json version to be stable x.y.z, received "${version}".`,
+		);
+	}
+
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+		patch: Number(match[3]),
+	};
+}
+
+function bumpVersion(version, bumpType) {
+	if (bumpType === "major") {
+		return { major: version.major + 1, minor: 0, patch: 0 };
+	}
+
+	if (bumpType === "minor") {
+		return { major: version.major, minor: version.minor + 1, patch: 0 };
+	}
+
+	return {
+		major: version.major,
+		minor: version.minor,
+		patch: version.patch + 1,
+	};
+}
+
+function readPublishedVersions(packageName) {
+	try {
+		const output = execFileSync(
+			"npm",
+			["view", packageName, "versions", "--json"],
+			{
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+
+		const parsed = JSON.parse(output);
+
+		if (Array.isArray(parsed)) {
+			return parsed;
+		}
+
+		return parsed ? [parsed] : [];
+	} catch (error) {
+		const stderr = String(error.stderr ?? "");
+
+		if (stderr.includes("E404")) {
+			return [];
+		}
+
+		throw error;
+	}
+}
+
+function nextPrereleaseNumber(versions, prefix) {
+	let max = -1;
+
+	for (const version of versions) {
+		if (!version.startsWith(prefix)) {
+			continue;
+		}
+
+		const prereleaseNumber = Number(version.slice(prefix.length));
+
+		if (Number.isInteger(prereleaseNumber) && prereleaseNumber > max) {
+			max = prereleaseNumber;
+		}
+	}
+
+	return max + 1;
+}
+
+function writeOutput(name, value) {
+	const outputPath = process.env.GITHUB_OUTPUT;
+
+	if (!outputPath) {
+		return;
+	}
+
+	appendFileSync(outputPath, `${name}=${value}\n`);
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,36 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel. stable opens/updates the Release Please PR; alpha/beta/rc publish an npm prerelease."
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - alpha
+          - beta
+          - rc
+      bump:
+        description: "Base version bump for prereleases."
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Prepare the prerelease without publishing it."
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   release-please:
     name: Release Please
+    if: ${{ github.event_name == 'push' || inputs.channel == 'stable' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -54,3 +80,56 @@ jobs:
         if: ${{ steps.release.outputs['packages/react-native-screen-transitions--release_created'] == 'true' }}
         working-directory: packages/react-native-screen-transitions
         run: npm publish --access public
+
+  prerelease:
+    name: Prerelease
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.channel != 'stable' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.20
+
+      - name: Setup Node (for npm trusted publishing)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install deps
+        run: bun install --frozen-lockfile
+
+      - name: Resolve prerelease version
+        id: version
+        env:
+          PRERELEASE_CHANNEL: ${{ inputs.channel }}
+          PRERELEASE_BUMP: ${{ inputs.bump }}
+        run: node .github/scripts/resolve-prerelease-version.mjs
+
+      - name: Set package version
+        working-directory: packages/react-native-screen-transitions
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      - name: Build
+        run: bun run build
+
+      - name: Pack preview
+        working-directory: packages/react-native-screen-transitions
+        run: npm pack --dry-run
+
+      - name: Publish prerelease to npm
+        if: ${{ inputs.dry_run == false }}
+        working-directory: packages/react-native-screen-transitions
+        run: npm publish --access public --tag "${{ inputs.channel }}"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run != false }}
+        run: echo "Prepared react-native-screen-transitions@${{ steps.version.outputs.version }} for npm tag ${{ inputs.channel }}. Re-run with dry_run=false to publish."

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
 		"lint": "biome check packages/react-native-screen-transitions/src",
 		"typecheck": "tsc -p packages/react-native-screen-transitions/tsconfig.typecheck.json",
 		"release": "bun run release:please",
-		"release:please": "gh workflow run release.yml --ref main",
+		"release:please": "gh workflow run release.yml --ref main -f channel=stable",
+		"release:alpha": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=false",
+		"release:alpha:dry-run": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=true",
+		"release:beta": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=false",
+		"release:beta:dry-run": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=true",
+		"release:rc": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=false",
+		"release:rc:dry-run": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=true",
 		"release:status": "gh run list --workflow release.yml --limit 5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- add manual `alpha`, `beta`, and `rc` channels to the existing `release.yml` workflow
- keep stable Release Please behavior on pushes to `main`
- add `source_ref` so prereleases can build from a stabilization branch like `release/v3.6` while using the trusted workflow from `main`
- add a resolver script that calculates the next npm prerelease version from the checked-out package version and already-published npm versions
- add safe root scripts for triggering prerelease dry-runs or publishes through GitHub Actions

## Usage

From GitHub Actions, run **Release Please** manually from `main`:

- `channel=alpha|beta|rc`
- `bump=patch|minor|major`
- `source_ref=release/v3.6` or another branch/tag to build
- `dry_run=true` to preview, `dry_run=false` to publish

Examples:

- package `3.5.1`, `source_ref=main`, `channel=beta`, `bump=patch` -> `3.5.2-beta.0`
- package `3.5.1`, `source_ref=release/v3.6`, `channel=beta`, `bump=minor` -> `3.6.0-beta.0`

Published prereleases use matching npm dist-tags, so consumers install with `react-native-screen-transitions@beta`, `@alpha`, or `@rc`.

## Validation

- `PRERELEASE_CHANNEL=beta PRERELEASE_BUMP=patch node .github/scripts/resolve-prerelease-version.mjs`
- `PRERELEASE_CHANNEL=beta PRERELEASE_BUMP=minor node .github/scripts/resolve-prerelease-version.mjs`
- `GITHUB_OUTPUT=/tmp/prerelease-output.txt PRERELEASE_CHANNEL=alpha PRERELEASE_BUMP=minor node .github/scripts/resolve-prerelease-version.mjs`
- `ruby -ryaml -e 'YAML.load_file(%q(.github/workflows/release.yml)); puts %q(yaml ok)'`
- `bunx biome check package.json .github/scripts/resolve-prerelease-version.mjs release-please-config.json .release-please-manifest.json`
- `git diff --check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Note: the first lint/typecheck attempt in the fresh worktree ran before `bun install` finished and failed with missing local binaries; rerunning after install passed.