### PR TITLE
chore: add prerelease source ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ on:
           - patch
           - minor
           - major
+      source_ref:
+        description: "Git ref to build for prereleases, such as release/v3.6."
+        required: true
+        default: main
+        type: string
       dry_run:
         description: "Prepare the prerelease without publishing it."
         required: true
@@ -92,6 +97,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
 		"typecheck": "tsc -p packages/react-native-screen-transitions/tsconfig.typecheck.json",
 		"release": "bun run release:please",
 		"release:please": "gh workflow run release.yml --ref main -f channel=stable",
-		"release:alpha": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=false",
-		"release:alpha:dry-run": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=true",
-		"release:beta": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=false",
-		"release:beta:dry-run": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=true",
-		"release:rc": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=false",
-		"release:rc:dry-run": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=true",
+		"release:alpha": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:alpha:dry-run": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f source_ref=main -f dry_run=true",
+		"release:beta": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:beta:dry-run": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f source_ref=main -f dry_run=true",
+		"release:rc": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:rc:dry-run": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f source_ref=main -f dry_run=true",
 		"release:status": "gh run list --workflow release.yml --limit 5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- add a `source_ref` manual workflow input for prereleases
- make the prerelease checkout build the selected source ref, such as `release/v3.6`, while still using the trusted workflow from `main`
- pass `source_ref=main` through the root helper scripts so existing CLI shortcuts keep working

## Why

GitHub Actions uses the selected **Use workflow from** branch to load the workflow file. For npm Trusted Publishing, we want that workflow file to come from `main`, but prerelease packages should be able to build from a stabilization branch like `release/v3.6`.

## Usage

Run **Release Please** manually with:

- Use workflow from: `main`
- `channel`: `alpha`, `beta`, or `rc`
- `bump`: `patch`, `minor`, or `major`
- `source_ref`: `release/v3.6`
- `dry_run`: `true` first, then `false` to publish

## Validation

- `ruby -ryaml -e 'YAML.load_file(%q(.github/workflows/release.yml)); puts %q(yaml ok)'`
- `bunx biome check package.json .github/scripts/resolve-prerelease-version.mjs release-please-config.json .release-please-manifest.json`
- `PRERELEASE_CHANNEL=beta PRERELEASE_BUMP=minor node .github/scripts/resolve-prerelease-version.mjs`
- `git diff --check`