### PR TITLE
chore: keep prerelease automation checkout separate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ on:
           - patch
           - minor
           - major
+      source_ref:
+        description: "Git ref to build for prereleases, such as release/v3.6."
+        required: true
+        default: main
+        type: string
       dry_run:
         description: "Prepare the prerelease without publishing it."
         required: true
@@ -90,8 +95,14 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout
+      - name: Checkout automation
         uses: actions/checkout@v4
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: source
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -105,29 +116,32 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install deps
+        working-directory: source
         run: bun install --frozen-lockfile
 
       - name: Resolve prerelease version
         id: version
         env:
+          PACKAGE_DIR: source/packages/react-native-screen-transitions
           PRERELEASE_CHANNEL: ${{ inputs.channel }}
           PRERELEASE_BUMP: ${{ inputs.bump }}
         run: node .github/scripts/resolve-prerelease-version.mjs
 
       - name: Set package version
-        working-directory: packages/react-native-screen-transitions
+        working-directory: source/packages/react-native-screen-transitions
         run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
 
       - name: Build
+        working-directory: source
         run: bun run build
 
       - name: Pack preview
-        working-directory: packages/react-native-screen-transitions
+        working-directory: source/packages/react-native-screen-transitions
         run: npm pack --dry-run
 
       - name: Publish prerelease to npm
         if: ${{ inputs.dry_run == false }}
-        working-directory: packages/react-native-screen-transitions
+        working-directory: source/packages/react-native-screen-transitions
         run: npm publish --access public --tag "${{ inputs.channel }}"
 
       - name: Dry run summary

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
 		"typecheck": "tsc -p packages/react-native-screen-transitions/tsconfig.typecheck.json",
 		"release": "bun run release:please",
 		"release:please": "gh workflow run release.yml --ref main -f channel=stable",
-		"release:alpha": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=false",
-		"release:alpha:dry-run": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f dry_run=true",
-		"release:beta": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=false",
-		"release:beta:dry-run": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f dry_run=true",
-		"release:rc": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=false",
-		"release:rc:dry-run": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f dry_run=true",
+		"release:alpha": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:alpha:dry-run": "gh workflow run release.yml --ref main -f channel=alpha -f bump=patch -f source_ref=main -f dry_run=true",
+		"release:beta": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:beta:dry-run": "gh workflow run release.yml --ref main -f channel=beta -f bump=patch -f source_ref=main -f dry_run=true",
+		"release:rc": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f source_ref=main -f dry_run=false",
+		"release:rc:dry-run": "gh workflow run release.yml --ref main -f channel=rc -f bump=patch -f source_ref=main -f dry_run=true",
 		"release:status": "gh run list --workflow release.yml --limit 5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- keep the workflow/automation checkout at the repository root
- checkout `source_ref` into `source/` for prerelease builds
- run dependency install, version mutation, build, pack, and publish from `source/`
- point the version resolver at `source/packages/react-native-screen-transitions`

## Why

The previous prerelease workflow checked out `source_ref` into the root workspace. That replaced the `main` workflow checkout, so helper scripts from `main` disappeared when `source_ref` was a release branch that did not contain them.

This keeps trusted automation from `main` and source code from the selected branch separate.

## Validation

- `ruby -ryaml -e 'YAML.load_file(%q(.github/workflows/release.yml)); puts %q(yaml ok)'`
- `bunx biome check package.json .github/scripts/resolve-prerelease-version.mjs release-please-config.json .release-please-manifest.json`
- `PACKAGE_DIR=/tmp/rnst-prerelease-source/packages/react-native-screen-transitions PRERELEASE_CHANNEL=beta PRERELEASE_BUMP=minor node .github/scripts/resolve-prerelease-version.mjs`
- `git diff --check`