### PR TITLE
fix: keep prerelease automation checkout on workflow ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,6 @@ jobs:
     steps:
       - name: Checkout automation
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.source_ref }}
 
       - name: Checkout source
         uses: actions/checkout@v4
@@ -131,7 +129,22 @@ jobs:
 
       - name: Set package version
         working-directory: source/packages/react-native-screen-transitions
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node --input-type=module <<'EOF'
+          import { readFileSync, writeFileSync } from "node:fs";
+
+          const packageJsonPath = "package.json";
+          const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+
+          packageJson.version = process.env.PACKAGE_VERSION;
+
+          writeFileSync(
+            packageJsonPath,
+            `${JSON.stringify(packageJson, null, "\t")}\n`,
+          );
+          EOF
 
       - name: Build
         working-directory: source


### PR DESCRIPTION
## Summary

- remove the accidental `source_ref` override from the automation checkout
- keep only the source checkout pointed at `inputs.source_ref`
- replace `npm version` with a direct package.json version write so npm does not try to resolve Bun workspace dependencies

## Why

The prerelease job needs the root checkout to stay on the workflow ref (`main`) so `.github/scripts/resolve-prerelease-version.mjs` exists. Only the `source/` checkout should use `release/v3.6` or another source branch.

`npm version` is also not safe in this workspace because npm tries to interpret workspace dependency protocols. For prerelease packaging we only need the package manifest version changed before `npm pack`/`npm publish`, so the workflow writes that field directly.

## Validation

- `ruby -ryaml -e 'YAML.load_file(%q(.github/workflows/release.yml)); puts %q(yaml ok)'`
- package version write smoke test produced `3.6.0-alpha.0`
- `git diff --check`