### PR TITLE
fix: replace removed absolute fill alias

### DIFF
--- a/packages/react-native-screen-transitions/src/shared/components/overlay/variations/overlay-host.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/overlay/variations/overlay-host.tsx
@@ -45,11 +45,14 @@ export const OverlayHost = memo(function OverlayHost({
 	return (
 		<Animated.View
 			pointerEvents="box-none"
-			style={[styles.container, styles.floating, styles.absolute]}
+			style={[styles.container, styles.floating, StyleSheet.absoluteFill]}
 		>
 			<NavigationContext.Provider value={scene.descriptor.navigation as any}>
 				<NavigationRouteContext.Provider value={scene.route}>
-					<View pointerEvents="box-none" style={styles.overlay}>
+					<View
+						pointerEvents="box-none"
+						style={[StyleSheet.absoluteFill, styles.overlay]}
+					>
 						<OverlayComponent {...overlayProps} />
 					</View>
 				</NavigationRouteContext.Provider>
@@ -60,13 +63,11 @@ export const OverlayHost = memo(function OverlayHost({
 
 const styles = StyleSheet.create({
 	overlay: {
-		...StyleSheet.absoluteFillObject,
 		zIndex: 1,
 	},
 	container: {
 		flex: 1,
 	},
-	absolute: StyleSheet.absoluteFillObject,
 	floating: {
 		zIndex: 1000,
 	},

--- a/packages/react-native-screen-transitions/src/shared/components/screen-container/layers/backdrop.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/screen-container/layers/backdrop.tsx
@@ -118,7 +118,7 @@ export const BackdropLayer = memo(function BackdropLayer({
 
 	return (
 		<Pressable
-			style={StyleSheet.absoluteFillObject}
+			style={StyleSheet.absoluteFill}
 			pointerEvents={isBackdropActive ? "auto" : "none"}
 			onPress={isBackdropActive ? handleBackdropPress : undefined}
 		>
@@ -127,13 +127,11 @@ export const BackdropLayer = memo(function BackdropLayer({
 			 * animated style with animatedProps can break intensity updates. */}
 			{AnimatedBackdropComponent && (
 				<AnimatedBackdropComponent
-					style={[StyleSheet.absoluteFillObject]}
+					style={[StyleSheet.absoluteFill]}
 					animatedProps={animatedBackdropProps}
 				/>
 			)}
-			<Animated.View
-				style={[StyleSheet.absoluteFillObject, animatedBackdropStyle]}
-			/>
+			<Animated.View style={[StyleSheet.absoluteFill, animatedBackdropStyle]} />
 		</Pressable>
 	);
 });

--- a/packages/react-native-screen-transitions/src/shared/providers/screen/styles/components/maybe-floating-container.tsx
+++ b/packages/react-native-screen-transitions/src/shared/providers/screen/styles/components/maybe-floating-container.tsx
@@ -15,7 +15,10 @@ export const MaybeFloatingContainer = memo(function MaybeFloatingContainer({
 	}
 
 	return (
-		<View style={styles.float} pointerEvents="box-none">
+		<View
+			style={[StyleSheet.absoluteFill, styles.float]}
+			pointerEvents="box-none"
+		>
 			{children}
 		</View>
 	);
@@ -23,7 +26,6 @@ export const MaybeFloatingContainer = memo(function MaybeFloatingContainer({
 
 const styles = StyleSheet.create({
 	float: {
-		...StyleSheet.absoluteFillObject,
 		zIndex: 999,
 	},
 });


### PR DESCRIPTION
## Summary

Replaces remaining uses of the deprecated `StyleSheet.absoluteFillObject` alias with `StyleSheet.absoluteFill` in internal full-screen transition layers.

## Why

React Native 0.85 fully removes `StyleSheet.absoluteFillObject`. The removed alias caused backdrop and floating overlay layers to lose their full-screen positioning, so backdrop rendering appeared broken in RN 0.85 repros.

## Validation

- `bun run lint`
- `bun run typecheck`
- Verified the minimal package `src` patch in the RN 0.85 repro at `/Users/ed/dev/tmp/liquid-glass-bug` by copying it into `node_modules/react-native-screen-transitions/src` and confirming the app rendered again.