### PR TITLE
docs: update funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,5 @@
-# GitHub uses this file to show the repository Sponsor button.
-github: eds2002
+# These are supported funding model platforms
+
+github: [eds2002]
 buy_me_a_coffee: trpfsu
+custom: ["https://buymeacoffee.com/trpfsu"]


### PR DESCRIPTION
## Summary

- Use the documented array form for GitHub Sponsors in `FUNDING.yml`.
- Add a quoted custom Buy Me a Coffee URL as a fallback funding link.

## Context

The repo has `FUNDING.yml` on `main`, but GitHub is not currently exposing repository `fundingLinks`, so this reshapes the file to GitHub's documented template style and adds an explicit custom link.

## Validation

- `git diff --check`