### PR TITLE
fix: mount ScreenOptionsProvider in FloatOverlay

### DIFF
--- a/packages/react-native-screen-transitions/src/shared/components/overlay/variations/float-overlay.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/overlay/variations/float-overlay.tsx
@@ -5,6 +5,7 @@ import { useStack } from "../../../hooks/navigation/use-stack";
 import { ScreenAnimationProvider } from "../../../providers/screen/animation";
 import type { BaseDescriptor } from "../../../providers/screen/descriptors";
 import { DescriptorsProvider } from "../../../providers/screen/descriptors";
+import { ScreenOptionsProvider } from "../../../providers/screen/options";
 import { ScreenStylesProvider } from "../../../providers/screen/styles";
 import type { OverlayScreenState } from "../../../types/overlay.types";
 
@@ -70,11 +71,16 @@ export function FloatOverlay() {
 
 	return (
 		<DescriptorsProvider current={current} previous={previous} next={next}>
-			<ScreenAnimationProvider>
-				<ScreenStylesProvider isFloatingOverlay>
-					<OverlayHost scene={scene} overlayScreenState={overlayScreenState} />
-				</ScreenStylesProvider>
-			</ScreenAnimationProvider>
+			<ScreenOptionsProvider>
+				<ScreenAnimationProvider>
+					<ScreenStylesProvider isFloatingOverlay>
+						<OverlayHost
+							scene={scene}
+							overlayScreenState={overlayScreenState}
+						/>
+					</ScreenStylesProvider>
+				</ScreenAnimationProvider>
+			</ScreenOptionsProvider>
 		</DescriptorsProvider>
 	);
 }


### PR DESCRIPTION
## Bug

Any screen with an `overlay` option crashes as soon as it becomes focused:

```
Error: ScreenOptions context must be used within a ScreenOptionsProvider
```

FloatOverlay renders ScreenStylesProvider without a ScreenOptionsProvider above it. ScreenStylesProvider calls `useScreenOptionsContext()` internally (in `use-interpolated-style-maps.tsx`), so it throws every time. Regular screens are fine because ScreenComposer mounts ScreenOptionsProvider.

Happens on 3.7.0, still present on main.

## Repro

```tsx
<Stack.Screen
  name="onboarding"
  component={OnboardingScreen}
  options={{ overlay: MyOverlay, overlayShown: true }}
/>
```

Navigate to the screen and it throws.

## Fix

Added ScreenOptionsProvider to FloatOverlay, same provider order as ScreenComposer. It only needs the descriptors context, which is already there.