### PR TITLE
fix: bounds transitions are mirrored in RTL

### DIFF
--- a/packages/react-native-screen-transitions/src/shared/components/boundary/portal/components/boundary-portal/components/portal-boundary-host.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/boundary/portal/components/boundary-portal/components/portal-boundary-host.tsx
@@ -1,5 +1,10 @@
 import { memo } from "react";
-import { type StyleProp, StyleSheet, type ViewStyle } from "react-native";
+import {
+	I18nManager,
+	type StyleProp,
+	StyleSheet,
+	type ViewStyle,
+} from "react-native";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
 import { NO_STYLES } from "../../../../../../constants";
 import { composeSlotStyleWithLocalTransform } from "../../../../../../providers/screen/styles/helpers/compose-slot-style";
@@ -155,10 +160,20 @@ export const PortalBoundaryHost = memo(function PortalBoundaryHost({
 	);
 });
 
+// The teleport offset is a physical page delta measured from the screen's
+// left edge, so the content box must anchor there too. Under native RTL,
+// `left: 0` swaps to a right-edge anchor; `end: 0` is the physical left edge
+// in RTL regardless of the swap setting.
 const styles = StyleSheet.create({
-	content: {
-		left: 0,
-		position: "absolute",
-		top: 0,
-	},
+	content: I18nManager.isRTL
+		? {
+				end: 0,
+				position: "absolute",
+				top: 0,
+			}
+		: {
+				left: 0,
+				position: "absolute",
+				top: 0,
+			},
 });

--- a/packages/react-native-screen-transitions/src/shared/components/masked-view.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/masked-view.tsx
@@ -1,4 +1,10 @@
-import { type StyleProp, StyleSheet, View, type ViewStyle } from "react-native";
+import {
+	I18nManager,
+	type StyleProp,
+	StyleSheet,
+	View,
+	type ViewStyle,
+} from "react-native";
 import { CONTAINER_STYLE_ID, MASK_STYLE_ID } from "../constants";
 import { createTransitionAwareComponent } from "./create-transition-aware-component";
 
@@ -49,9 +55,19 @@ const styles = StyleSheet.create({
 	root: {
 		flex: 1,
 	},
-	rootMask: {
-		backgroundColor: "white",
-	},
+	// The mask rect's translate math assumes a physical top-left base. Under
+	// native RTL a fixed-width flex child anchors to the right edge, so pin it
+	// to the physical left (`end` = left edge in RTL).
+	rootMask: I18nManager.isRTL
+		? {
+				backgroundColor: "white",
+				end: 0,
+				position: "absolute",
+				top: 0,
+			}
+		: {
+				backgroundColor: "white",
+			},
 	rootContainer: {
 		flex: 1,
 	},

--- a/packages/react-native-screen-transitions/src/shared/components/screen-container/layers/maybe-masked-navigation-container.tsx
+++ b/packages/react-native-screen-transitions/src/shared/components/screen-container/layers/maybe-masked-navigation-container.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from "react";
-import { StyleSheet, View, type ViewProps } from "react-native";
+import { I18nManager, StyleSheet, View, type ViewProps } from "react-native";
 import Animated from "react-native-reanimated";
 import {
 	NAVIGATION_MASK_CONTAINER_STYLE_ID,
@@ -97,7 +97,17 @@ const styles = StyleSheet.create({
 	navigationContainer: {
 		flex: 1,
 	},
-	navigationMaskElement: {
-		backgroundColor: "white",
-	},
+	// The mask rect's translate math assumes a physical top-left base. Under
+	// native RTL a fixed-width flex child anchors to the right edge, so pin it
+	// to the physical left (`end` = left edge in RTL).
+	navigationMaskElement: I18nManager.isRTL
+		? {
+				backgroundColor: "white",
+				end: 0,
+				position: "absolute",
+				top: 0,
+			}
+		: {
+				backgroundColor: "white",
+			},
 });


### PR DESCRIPTION
## Problem

On apps running in native RTL (`I18nManager.isRTL`), every bounds/zoom transition is horizontally mirrored. An element sitting on the left side of the screen opens from the right, dismisses to the right, then snaps to its real position when the transition pair tears down. Drag gestures track the finger correctly the whole time.

## Cause

The translate math works in physical page coordinates measured from the left edge of the screen, but three fixed width boxes assume a physical top-left anchor, and RTL layout moves that anchor to the right edge:

- `portal-boundary-host.tsx`: the teleported clone is absolutely positioned with `left: 0` plus an explicit source width. With RN's default `doLeftAndRightSwapInRTL`, `left: 0` becomes a right edge anchor in RTL, so the clone's base is `screenWidth - width` instead of 0.
- `maybe-masked-navigation-container.tsx`: the navigation mask element is a fixed width flex child, and cross axis flex-start is the right edge in RTL.
- `masked-view.tsx` (deprecated): same pattern as the mask above.

## Fix

Pin these boxes to the physical left edge when RTL is active. In RTL, `end: 0` always means the physical left edge, regardless of the swap setting. The LTR code path is byte identical to before. `I18nManager.isRTL` is fixed at app launch, so reading it at module scope is safe with worklets.

With this change the package works perfectly in RTL apps, which opens it up to a whole set of locales it did not support well before.

## Why not fix the transform math instead

- Drag gestures are already correct in RTL, which means Reanimated applies `translateX` physically, not mirrored. Negating the transforms fixes the flight but breaks the gestures (tried it).
- Mirroring the measured `pageX` sends the flight off screen, so Fabric measurements are physical too (also tried).
- Only anchoring the base to the physical left fixes open, dismiss, and gestures at once.

Found in a production RTL app, where we have been running this fix as a local patch and it works perfectly. Verified on an Android device with an Arabic locale: grid to detail zoom with `escapeClipping` and `navigationMaskEnabled`, open, dismiss, and all drag gestures correct, LTR unchanged. `bun run lint` and `bun run typecheck` pass.
