### PR TITLE
docs(release): add v3.11.3 notes

### DIFF
--- a/packages/react-native-screen-transitions/CHANGELOG.md
+++ b/packages/react-native-screen-transitions/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [3.11.3](https://github.com/eds2002/react-native-screen-transitions/compare/v3.11.2...v3.11.3) (2026-08-06)
 
+### Bug Fixes
+
+* **bounds:** refresh grouped boundary retargets and stabilize escaped source portals
+* **lifecycle:** unify gesture and programmatic dismissal completion
+
+### Performance Improvements
+
+* **bounds:** isolate boundary measurement lifecycle updates
+
 ## [3.11.2](https://github.com/eds2002/react-native-screen-transitions/compare/v3.11.1...v3.11.2) (2026-08-03)
 
 ## [3.11.1](https://github.com/eds2002/react-native-screen-transitions/compare/v3.11.0...v3.11.1) (2026-07-30)


### PR DESCRIPTION
## What changed

- documents the fixes and performance improvement already included in v3.11.3
- retriggers the stable release workflow for the unpublished package version

## Why

The original v3.11.3 merge updated the package version and changelog heading, but no Release workflow run was created. npm still reports `latest` as 3.11.2, and the repository release validator confirms 3.11.3 is unpublished and its tag is free.

## Validation

- stable release eligibility check passes
- v3.11.3 release notes check passes
- changelog diff check passes