### PR TITLE
docs: require teleport 1.2.0 as minimal supported version

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -45,7 +45,7 @@
 		"react-native-safe-area-context": "~5.6.0",
 		"react-native-screen-transitions": "workspace:*",
 		"react-native-screens": "~4.23.0",
-		"react-native-teleport": "1.1.10",
+		"react-native-teleport": "1.2.0",
 		"react-native-web": "~0.21.0",
 		"react-native-worklets": "0.7.4",
 		"zustand": "^5.0.11"

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screen-transitions": "workspace:*",
         "react-native-screens": "~4.23.0",
-        "react-native-teleport": "1.1.10",
+        "react-native-teleport": "1.2.0",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.7.4",
         "zustand": "^5.0.11",
@@ -107,7 +107,7 @@
         "react-native-reanimated": ">=3.16.0 || >=4.0.0-",
         "react-native-safe-area-context": "*",
         "react-native-screens": ">=4.4.0",
-        "react-native-teleport": ">=1.1.0 <1.1.11",
+        "react-native-teleport": ">=1.2.0",
       },
       "optionalPeers": [
         "react-native-teleport",
@@ -2918,7 +2918,7 @@
 
     "react-native-screens": ["react-native-screens@4.23.0", "", { "dependencies": { "react-freeze": "^1.0.0", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw=="],
 
-    "react-native-teleport": ["react-native-teleport@1.1.10", "", { "peerDependencies": { "react": "*", "react-dom": "*", "react-native": "*" } }, "sha512-dd95Ni4wcD7o9uXZ2WHksWKH0OSlXKV6/AvJVKm4FXUxaWTj+0DCd3dey+7zB72t/UkEBwGoXFM2g5QMXwj68Q=="],
+    "react-native-teleport": ["react-native-teleport@1.2.0", "", { "peerDependencies": { "react": "*", "react-dom": "*", "react-native": "*" } }, "sha512-ER+fwiWGnTySSDQ3J+gX0wQjPmYQuyFMy6OYBTaPhEzRChEisVm/h7qvaEDJ0SHRbT5+FMjcfaE80pOEl3BFUQ=="],
 
     "react-native-web": ["react-native-web@0.21.2", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@react-native/normalize-colors": "^0.74.1", "fbjs": "^3.0.4", "inline-style-prefixer": "^7.0.1", "memoize-one": "^6.0.0", "nullthrows": "^1.1.1", "postcss-value-parser": "^4.2.0", "styleq": "^0.1.3" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg=="],
 

--- a/packages/docs/src/content/docs/caveats.mdx
+++ b/packages/docs/src/content/docs/caveats.mdx
@@ -108,7 +108,7 @@ The feature moves one live payload between matching boundary hosts. It's useful 
 In particular, Android video surfaces have a trade-off:
 
 - `SurfaceView` is efficient, but it may render outside normal React Native clipping, transforms, border radii, or portal stacking.
-- `TextureView` participates in the regular view hierarchy, but it can briefly flicker when native content moves between handoff hosts.
+- `TextureView` participates in the regular view hierarchy and works with the native reparenting fast path in `react-native-teleport@1.2.0`.
 
 For Expo Video content that must clip or animate with a boundary, prefer:
 

--- a/packages/docs/src/content/docs/shared-elements.mdx
+++ b/packages/docs/src/content/docs/shared-elements.mdx
@@ -243,12 +243,12 @@ Use `escapeClipping` when a boundary needs to render outside local clipping or l
 `handoff` and `escapeClipping` use `react-native-teleport` under the hood. Install the supported version when using either prop:
 
 ```sh
-bun add react-native-teleport@1.1.10
+bun add react-native-teleport@1.2.0
 ```
 
-The supported range is `>=1.1.0 <1.1.11`. Version `1.1.11` is not compatible with continuously animated boundary hosts.
+Version `1.2.0` uses the native reparenting fast path for live payloads, including handed-off video.
 
-Test handed-off video on physical Android devices. A `SurfaceView` may not obey portal clipping or transforms, while a `TextureView` participates in normal view composition but can briefly flicker while its native surface moves between hosts. For Expo Video, `surfaceType="textureView"` is usually the correct choice when clipping and transforms matter.
+Test handed-off video on physical Android devices. A `SurfaceView` may not obey portal clipping or transforms, while a `TextureView` participates in normal view composition. For Expo Video, `surfaceType="textureView"` is usually the correct choice when clipping and transforms matter.
 
 See [Caveats & Trade-offs](/caveats) for the current handoff support boundary.
 

--- a/packages/docs/src/content/docs/updating-to-3-9.mdx
+++ b/packages/docs/src/content/docs/updating-to-3-9.mdx
@@ -195,10 +195,10 @@ Use `handoff` and `escapeClipping` together when both behaviors are needed:
 `handoff` and `escapeClipping` use `react-native-teleport` under the hood. If you use either prop, install the optional peer dependency:
 
 ```sh
-bun add react-native-teleport@1.1.10
+bun add react-native-teleport@1.2.0
 ```
 
-The supported range is `>=1.1.0 <1.1.11`. Version `1.1.11` is excluded because its host-size synchronization can trail continuously animated boundary hosts. Pin `1.1.10` when using either feature.
+Version `1.2.0` uses the native reparenting fast path for live payloads, including handed-off video. Pin `1.2.0` when using either feature.
 
 ## Better Retargeting
 
@@ -420,7 +420,7 @@ For `method: "size"`, the returned scale is applied to the generated width and h
 - Prefer `Transition.Boundary` over `Transition.Boundary.View` and `Transition.Boundary.Trigger`.
 - Use `handoff` on every matching boundary that should send or receive a live payload.
 - Use `escapeClipping` when a boundary needs to render outside local clipping constraints during a transition.
-- Install `react-native-teleport@1.1.10` if you use `handoff` or `escapeClipping`.
+- Install `react-native-teleport@1.2.0` if you use `handoff` or `escapeClipping`.
 - Replace `bounds({ id, ...options })` style output with `bounds(id).styles(options)`.
 - Replace raw numeric bounds usage with `bounds(id).values(options)`.
 - Replace earlier beta `bounds(id).math(options)` usage with `bounds(id).values(options)`. `math()` remains as a deprecated alias.

--- a/packages/docs/src/content/docs/v4-experimental/installation.mdx
+++ b/packages/docs/src/content/docs/v4-experimental/installation.mdx
@@ -135,10 +135,10 @@ Install the compatible teleport package when using boundary teleportation:
   defaultTab="npm"
   syncKey="package-manager"
   tabs={[
-    { label: "npm", value: "npm", code: `npm install "react-native-teleport@>=1.1.0 <1.1.11"` },
-    { label: "yarn", value: "yarn", code: `yarn add "react-native-teleport@>=1.1.0 <1.1.11"` },
-    { label: "pnpm", value: "pnpm", code: `pnpm add "react-native-teleport@>=1.1.0 <1.1.11"` },
-    { label: "bun", value: "bun", code: `bun add "react-native-teleport@>=1.1.0 <1.1.11"` },
+    { label: "npm", value: "npm", code: `npm install react-native-teleport@1.2.0` },
+    { label: "yarn", value: "yarn", code: `yarn add react-native-teleport@1.2.0` },
+    { label: "pnpm", value: "pnpm", code: `pnpm add react-native-teleport@1.2.0` },
+    { label: "bun", value: "bun", code: `bun add react-native-teleport@1.2.0` },
   ]}
 />
 

--- a/packages/react-native-screen-transitions/package.json
+++ b/packages/react-native-screen-transitions/package.json
@@ -85,7 +85,7 @@
 		"react-native-reanimated": ">=3.16.0 || >=4.0.0-",
 		"react-native-safe-area-context": "*",
 		"react-native-screens": ">=4.4.0",
-		"react-native-teleport": ">=1.1.0 <1.1.11"
+		"react-native-teleport": ">=1.2.0"
 	},
 	"peerDependenciesMeta": {
 		"react-native-teleport": {


### PR DESCRIPTION
## Motivation

Hello, author of `react-native-teleport` is here 👋 

Recently I released `1.2.0` version of `react-native-teleport`. There I introduced "fast-path" for reparenting views on Android.

With fast-path both surface/texture `Video` views will not flicker while you are teleporting them. Effectively this is matching web/iOS specifications. So I decided to adjust documentation a little bit (keeping in mind that version `1.1.11` was broken I decided that it would be fair to bump minimal supported version to `1.2.0`).

And with `1.2.0` version some of information in documentation is not very actual (like video flickering). So I decided to adjust it a little bit.

Feel free to test a new version of teleport and let me know if you discover any bugs 🙌 Aso you can reach out to me via [discord](https://discordapp.com/users/973642097888489512) (nickname is kiryl.ziusko) - I'm responding there much faster 👀

Would be glad to help to tackle down any bugs that you encounter!

Also feel free to adjust documentation more if you think it's needed or ask me to do that. Because sometimes I have a feeling like documentation is trying to explain the difference between texture and surface and at the same time mention, that texture may not work well with teleportation. But keeping in mind that texture + teleportation bug is resolved I'm not sure whether you want to explain the difference anymore (but I kept it in documentation anyway) 🤷‍♂️ 
